### PR TITLE
fix: add @DirtyCheck on BaseEntity to fix errors in persistence on db

### DIFF
--- a/src/main/groovy/com/mini/asaas/utils/BaseEntity.groovy
+++ b/src/main/groovy/com/mini/asaas/utils/BaseEntity.groovy
@@ -1,6 +1,6 @@
 package com.mini.asaas.utils
-import grails.compiler.GrailsCompileStatic
 
+import grails.compiler.GrailsCompileStatic
 import grails.gorm.dirty.checking.DirtyCheck
 
 @DirtyCheck


### PR DESCRIPTION
## O que é
### A anotação @DirtyCheck na class BaseEntity se torna necessária para corrigir possíveis erros de persistência no banco de dados
## Impacto
### Agora será possível implementar um softdelete nas services que precisarem sem ter problema ao salvar
## Implementação:
![image](https://github.com/KarlaCSF/Mini-Asaas/assets/91269138/8ba2275f-3e83-4b68-bc7d-3369b76053d6)
