### PR TITLE
Named Queries in Payment and switched to payment/create page the begin of flux for create a Payment

### DIFF
--- a/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
@@ -13,8 +13,16 @@ class PaymentController {
 
     Customer customer = Customer.get(1) // todo: fix customer Id in 1 while don't have authentication
     
-    def index() {  
-        return [params: params]
+    def index(){
+        return [view:"index"]
+    }
+
+    def create() {  
+        try{
+            return [params: params]
+        } catch (Exception exception) {
+            log.error(exception.message, exception)
+        }
     }
 
     def edit() {
@@ -45,7 +53,7 @@ class PaymentController {
         } catch (Exception exception) {
             log.error("PaymentController.save >> Não foi possível salvar a Payment ${params.id}", exception)
             params.errorMessage = "Não foi possível realizar a cobrança"
-            redirect(view: "index", params: params)
+            redirect(view: "create", params: params)
         }
     }
     
@@ -57,7 +65,7 @@ class PaymentController {
         } catch (Exception exception) {
             log.error(exception.message, exception)
             params.errorMessage = "Não foi possível editar a cobrança"
-            redirect(view: "index", params: params)
+            redirect(view: "edit", params: params)
         }
     }
 
@@ -68,7 +76,7 @@ class PaymentController {
         } catch (Exception exception) {
             log.error(exception.message, exception)
             params.errorMessage = "Não foi possível apagar a cobrança"
-            redirect(view: "index", params: params)
+            redirect(view: "edit", params: params)
         }
     }
 }

--- a/grails-app/domain/com/mini/asaas/payment/Payment.groovy
+++ b/grails-app/domain/com/mini/asaas/payment/Payment.groovy
@@ -4,6 +4,7 @@ import com.mini.asaas.Payer
 import com.mini.asaas.Customer
 import com.mini.asaas.enums.payment.BillingType
 import com.mini.asaas.enums.payment.PaymentStatus
+import com.mini.asaas.namedqueries.NamedQueries
 import com.mini.asaas.utils.BaseEntity
 import grails.compiler.GrailsCompileStatic
 
@@ -30,5 +31,14 @@ class Payment extends BaseEntity {
         billingType blank:false
         status blank:false
     }
-    
+
+    static namedQueries = {
+        byCustomerAndPayment { Long paymentId, Long customerId ->
+            NamedQueries.applyDefaultQuery(delegate)
+            customer {
+                eq('id', customerId)
+            }
+            eq('id', paymentId)
+        }
+    }
 }

--- a/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
+++ b/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
@@ -35,11 +35,8 @@ class PaymentService {
     }
 
     public Payment update(UpdatePaymentDTO updatePaymentDTO, Long paymentId, Long customerId ) {
-        Payment payment = Payment.where{
-            id == paymentId 
-            && customer.id == customerId 
-            && deleted == false
-        }.first()
+        Payment payment = (Payment) Payment.byCustomerAndPayment(paymentId, customerId).get()
+        if(!payment) throw new Exception("PaymentService.update >> Não foi possível encontrar o Payment ${paymentId} do Customer ${customerId}")
         
         payment.lastUpdated = new Date()
         payment.value = updatePaymentDTO.value
@@ -50,21 +47,16 @@ class PaymentService {
     }
 
     public Payment show(Long paymentId, Long customerId) {
-        Payment payment = Payment.where{
-            id == paymentId 
-            && customer.id == customerId 
-            && deleted == false
-        }.first()
+        Payment payment = (Payment) Payment.byCustomerAndPayment(paymentId, customerId).get()
+        if(!payment) throw new Exception("PaymentService.show >> Não foi possível encontrar o Payment ${paymentId} do Customer ${customerId}")       
+        
         return payment
     }
     
     public void delete(Long paymentId, Long customerId) {
-        Payment payment = Payment.where{
-            id == paymentId 
-            && customer.id == customerId 
-            && deleted == false
-        }.first()
-
+        Payment payment = (Payment) Payment.byCustomerAndPayment(paymentId, customerId).get()
+        if(!payment) throw new Exception("PaymentService.delete >> Não foi possível encontrar o Payment ${paymentId} do Customer ${customerId}")
+        
         payment.deleted = true 
         payment.save(failOnError: true)
     }

--- a/grails-app/views/payment/create.gsp
+++ b/grails-app/views/payment/create.gsp
@@ -1,0 +1,51 @@
+<%@ page 
+import="com.mini.asaas.Payer"
+import="com.mini.asaas.enums.payment.BillingType"
+contentType="text/html;charset=UTF-8" %>
+<html>
+<head>
+    <title></title>
+    <html lang="pt-br">
+</head>
+
+<body>
+<form action="${createLink(controller: "payment", action: "save")}" method="POST">
+
+    <fieldset>
+        <legend>Criar Cobrança</legend>
+        
+        <g:if test="${params.errorMessage}">
+            <span>${params.errorMessage}</span>
+        </g:if>
+        
+        <g:if test="${params.successfulMessage}">
+            <span>${params.successfulMessage}</span>
+        </g:if>
+            
+        <fieldset>         
+            <div>
+                <label for="payerId">Escolha o Pagador</label><br>
+                <g:select name="payerId" from="${Payer.list()}" optionKey="id" optionValue="name" noSelection="['':'Selecione um pagador']" required="true"/><br>
+            </div><br>
+
+            <div>
+                <label for="name">Valor da cobrança</label><br>
+                <input type="number" placeholder="Insira o valor da cobrança" name="value" value="${params.value}" id="value" min="0.00" step="0.01" required><br>
+            </div><br>
+
+            <div>
+                <label for="email">Data de Vencimento</label><br>
+                <input type="date" placeholder="Insira a data de vencimento" name="dueDate" value="${params.dueDate}" id="dueDate" required><br>
+            </div><br>
+ 
+            <div>
+                <label for="billingType">Tipo de Pagamento</label><br>
+                <g:select name="billingType" from="${BillingType.values()}" valueMessagePrefix="BillingType" noSelection="['':'Selecione uma forma de pagamento']" required="true"/>
+            </div><br>
+        </fieldset>
+        
+        <input type="submit" value="Criar Cobrança">
+    </fieldset>
+</form>
+</body>
+</html>

--- a/grails-app/views/payment/index.gsp
+++ b/grails-app/views/payment/index.gsp
@@ -9,43 +9,7 @@ contentType="text/html;charset=UTF-8" %>
 </head>
 
 <body>
-<form action="${createLink(controller: "payment", action: "save")}" method="POST">
-
-    <fieldset>
-        <legend>Criar Cobrança</legend>
-        
-        <g:if test="${params.errorMessage}">
-            <span>${params.errorMessage}</span>
-        </g:if>
-        
-        <g:if test="${params.successfulMessage}">
-            <span>${params.successfulMessage}</span>
-        </g:if>
-            
-        <fieldset>         
-            <div>
-                <label for="payerId">Escolha o Pagador</label><br>
-                <g:select name="payerId" from="${Payer.list()}" optionKey="id" optionValue="name" noSelection="['':'Selecione um pagador']" required="true"/><br>
-            </div><br>
-
-            <div>
-                <label for="name">Valor da cobrança</label><br>
-                <input type="number" placeholder="Insira o valor da cobrança" name="value" value="${params.value}" id="value" min="0.00" step="0.01" required><br>
-            </div><br>
-
-            <div>
-                <label for="email">Data de Vencimento</label><br>
-                <input type="date" placeholder="Insira a data de vencimento" name="dueDate" value="${params.dueDate}" id="dueDate" required><br>
-            </div><br>
- 
-            <div>
-                <label for="billingType">Tipo de Pagamento</label><br>
-                <g:select name="billingType" from="${BillingType.values()}" valueMessagePrefix="BillingType" noSelection="['':'Selecione uma forma de pagamento']" required="true"/>
-            </div><br>
-        </fieldset>
-        
-        <input type="submit" value="Criar Cobrança">
-    </fieldset>
-</form>
+    <h2>Payments</h2>
+    <a href="${createLink(controller: 'payment', action: 'create')}">Criar Cobrança</a>
 </body>
 </html>

--- a/src/main/groovy/com/mini/asaas/namedqueries/NamedQueries.groovy
+++ b/src/main/groovy/com/mini/asaas/namedqueries/NamedQueries.groovy
@@ -1,0 +1,8 @@
+package com.mini.asaas.namedqueries
+
+class NamedQueries {
+
+    static applyDefaultQuery(delegate) {
+        delegate.eq('deleted', false)
+    }
+}


### PR DESCRIPTION
### Impacto
#### Payment agora usa de NamedQueries pra buscar um payment no banco, recebendo o id do Customer dono e o id da Payment referente. Também o começo do fluxo de cadastro de Payment foi movido para payment/create o que antes era em payment/index

### Release Note (Descrição que irá no forno)

### PR Predecessora
#### 14
### Plano de deploy:
- Antes do deploy:
- Depois do deploy:

### Link da tarefa no JIRA
#### https://asaasdev.atlassian.net/browse/PMAKES-26

### Link dos mockups

### Prints do desenvolvimento
#### Named Queries
![image](https://github.com/KarlaCSF/Mini-Asaas/assets/91269138/7bc64fb1-1155-4ac4-94ca-b7bd9aff4056)
#### Create Page
![image](https://github.com/KarlaCSF/Mini-Asaas/assets/91269138/d120758b-b080-4838-989e-0ccac2323e36)

