### PR TITLE
Enviar emails na criação, atualização e exclusão de payments

### DIFF
--- a/grails-app/services/com/mini/asaas/email/EmailService.groovy
+++ b/grails-app/services/com/mini/asaas/email/EmailService.groovy
@@ -10,6 +10,30 @@ import grails.compiler.GrailsCompileStatic
 class EmailService {
 
     MailService mailService
+    
+    public void sendEmailOnCreatePayment(Payment payment) {
+        mailService.sendMail {
+            to payment.payer.email
+            subject "Cobrança Criada - Número ${payment.id}"
+            body "Olá ${payment.payer.name}, foi criada uma cobrança no valor de ${payment.value}, por ${payment.customer.name} que vencerá no dia ${payment.dueDate}."
+        }
+    }
+    
+    public void sendEmailOnUpdatePayment(Payment payment) {
+        mailService.sendMail {
+            to payment.payer.email
+            subject "Cobrança atualizada - Número ${payment.id}"
+            body "Olá ${payment.payer.name}, a cobrança de número ${payment.id}, vinda de ${payment.customer.name}, foi alterada."
+        }
+    }
+
+    public void sendEmailOnDeletePayment(Payment payment) {
+        mailService.sendMail {
+            to payment.payer.email
+            subject "Cobrança excluída - Número ${payment.id}"
+            body "Olá ${payment.payer.name}, a cobrança de número ${payment.id}, no valor de ${payment.value} vinda de ${payment.customer.name} foi excluída."
+        }
+    }
 
     public void sendEmailToVerifyPayment(Payment payment) {
         mailService.sendMail {

--- a/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
+++ b/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
@@ -36,7 +36,10 @@ class PaymentService {
         payment.billingType = createPaymentDTO.billingType
         payment.status = createPaymentDTO.status
         
-        return payment.save(failOnError: true)
+        payment.save(failOnError: true)
+        notifyOnCreatePayment(payment)
+
+        return payment
     }
 
     public Payment update(UpdatePaymentDTO updatePaymentDTO, Long paymentId, Long customerId ) {
@@ -45,7 +48,11 @@ class PaymentService {
         payment.value = updatePaymentDTO.value
         payment.dueDate = updatePaymentDTO.dueDate
         payment.billingType = updatePaymentDTO.billingType
-        return payment.save(failOnError: true)
+        
+        payment.save(failOnError: true)
+        notifyOnUpdatePayment(payment)
+
+        return payment 
     }
 
     public Payment findByIdAndCustomerId(Long paymentId, Long customerId) {
@@ -56,7 +63,9 @@ class PaymentService {
         Payment payment = PaymentRepository.findByIdAndCustomerId(paymentId, customerId)
         if (!payment.canEdit()) throw new Exception("Essa cobrança não pode ser modificada")
         payment.deleted = true 
+
         payment.save(failOnError: true)
+        notifyOnDeletePayment(payment)
     }
 
     public List<Payment> listByCustomer(Long customerId){
@@ -73,5 +82,17 @@ class PaymentService {
         paymentList.each { payment ->
             emailService.sendEmailToVerifyPayment(payment)
         }
+    }
+
+    private void notifyOnCreatePayment(Payment payment) {
+        emailService.sendEmailOnCreatePayment(payment)
+    }
+
+    private void notifyOnUpdatePayment(Payment payment) {
+        emailService.sendEmailOnUpdatePayment(payment)
+    }
+    
+    private void notifyOnDeletePayment(Payment payment) {
+        emailService.sendEmailOnDeletePayment(payment)
     }
 }


### PR DESCRIPTION
## Impacto
### Agora será enviado emails sempre que fizer algo referente à payment, como criação, exclusão ou atualização

## Release Note (Descrição que irá no forno)

## PR Predecessora  
### https://github.com/KarlaCSF/Mini-Asaas/pull/24

## Plano de deploy:
- Antes do deploy:
- Depois do deploy: criar templates em gsp para enviar ao cliente um html ao invés de apenas texto

## Link da tarefa no JIRA
### https://asaasdev.atlassian.net/browse/PMAKES-40

## Prints do desenvolvimento
![image](https://github.com/KarlaCSF/Mini-Asaas/assets/91269138/503fe428-7881-464f-89bb-f3898ebf04a6)
