### PR TITLE
adicionando método para criar a mascara do cpf/cnpj

### DIFF
--- a/grails-app/services/com/mini/asaas/customer/CustomerService.groovy
+++ b/grails-app/services/com/mini/asaas/customer/CustomerService.groovy
@@ -4,7 +4,7 @@ package com.mini.asaas.customer
 import com.mini.asaas.address.AddressService
 import com.mini.asaas.dto.customer.CustomerDTO
 import com.mini.asaas.utils.CpfCnpjUtils
-
+import com.mini.asaas.utils.Util
 import grails.gorm.transactions.Transactional
 import grails.validation.ValidationException
 import grails.compiler.GrailsCompileStatic
@@ -22,7 +22,7 @@ class CustomerService {
 
         validatedCustomer.name = customerDTO.name
         validatedCustomer.email = customerDTO.email
-        validatedCustomer.cpfCnpj = customerDTO.cpfCnpj
+        validatedCustomer.cpfCnpj = Util.removeNonNumeric(customerDTO.cpfCnpj)
         validatedCustomer.personType = CpfCnpjUtils.getPersonType(validatedCustomer.cpfCnpj)
 
         validatedCustomer.address = addressService.save(customerDTO.addressDTO)
@@ -42,7 +42,7 @@ class CustomerService {
 
         validatedCustomer.name = customerDTO.name
         validatedCustomer.email = customerDTO.email
-        validatedCustomer.cpfCnpj = customerDTO.cpfCnpj
+        validatedCustomer.cpfCnpj = Util.removeNonNumeric(customerDTO.cpfCnpj)
         validatedCustomer.personType = CpfCnpjUtils.getPersonType(validatedCustomer.cpfCnpj)
         validatedCustomer.address = addressService.update(customerDTO.addressDTO, validatedCustomer.address.id)
 

--- a/grails-app/services/com/mini/asaas/payer/PayerService.groovy
+++ b/grails-app/services/com/mini/asaas/payer/PayerService.groovy
@@ -6,7 +6,7 @@ import com.mini.asaas.customer.Customer
 import com.mini.asaas.dto.payer.PayerDTO
 import com.mini.asaas.utils.CpfCnpjUtils
 import com.mini.asaas.repositories.PayerRepository
-
+import com.mini.asaas.utils.Util
 import grails.gorm.transactions.Transactional
 import grails.validation.ValidationException
 import grails.compiler.GrailsCompileStatic
@@ -24,7 +24,7 @@ class PayerService {
 
         validatedPayer.name = payerDTO.name
         validatedPayer.email = payerDTO.email
-        validatedPayer.cpfCnpj = payerDTO.cpfCnpj
+        validatedPayer.cpfCnpj = Util.removeNonNumeric(payerDTO.cpfCnpj)
         validatedPayer.customer = Customer.get(customerId)
         validatedPayer.personType = CpfCnpjUtils.getPersonType(validatedPayer.cpfCnpj)
 
@@ -42,7 +42,7 @@ class PayerService {
 
         validatedPayer.name = payerDTO.name
         validatedPayer.email = payerDTO.email
-        validatedPayer.cpfCnpj = payerDTO.cpfCnpj
+        validatedPayer.cpfCnpj = Util.removeNonNumeric(payerDTO.cpfCnpj)
         validatedPayer.personType = CpfCnpjUtils.getPersonType(validatedPayer.cpfCnpj)
         validatedPayer.address = addressService.update(payerDTO.addressDTO, validatedPayer.address.id)
 

--- a/grails-app/views/customer/show.gsp
+++ b/grails-app/views/customer/show.gsp
@@ -1,3 +1,4 @@
+<%@ page import="com.mini.asaas.utils.CpfCnpjUtils" %>
 <!doctype html>
 <html>
 <head>
@@ -12,7 +13,7 @@
         <input type="text" name="email" value="${customer.email}" disabled><br><br>
 
         <label for="cpfCnpj">CPF/CNPJ:</label><br>
-        <input type="text" name="cpfCnpj" value="${customer.cpfCnpj}" disabled><br><br>
+        <input type="text" name="cpfCnpj" value="${CpfCnpjUtils.applyMask(customer.cpfCnpj)}" disabled><br><br>
 
         <label for="tipo">Tipo de pessoa:</label><br>
         <input type="text" name="tipo" value="${customer.personType.getLabel()}" disabled><br><br>

--- a/grails-app/views/invoice/show.gsp
+++ b/grails-app/views/invoice/show.gsp
@@ -1,5 +1,5 @@
 <%@ page 
-import="com.mini.asaas.enums.payment.PaymentStatus"
+import="com.mini.asaas.utils.CpfCnpjUtils; com.mini.asaas.enums.payment.PaymentStatus"
 contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
@@ -17,7 +17,7 @@ contentType="text/html;charset=UTF-8" %>
             <label for="payerId">Responsável pela cobrança</label><br>
             <input type="text" value="${payment.customer.name}" disabled><br>
             <input type="text" value="${payment.customer.email}" disabled><br>
-            <input type="text" value="${payment.customer.cpfCnpj}" disabled><br>
+            <input type="text" value="${CpfCnpjUtils.applyMask(payment.customer.cpfCnpj)}" disabled><br>
         </div><br>
 
         <div>

--- a/grails-app/views/payer/show.gsp
+++ b/grails-app/views/payer/show.gsp
@@ -1,4 +1,5 @@
-<%@ page contentType="text/html;charset=UTF-8" %>
+<%@ page import="com.mini.asaas.utils.CpfCnpjUtils" %>
+<%@page contentType="text/html;charset=UTF-8" %>
 <html>
 <head>
     <title></title>
@@ -35,7 +36,7 @@
         
             <div>
                 <label for="cpfCnpj">CPF/CPNJ</label><br>
-                <input type="text"  value="${payer.cpfCnpj}" disabled="true"><br>
+                <input type="text" value="${CpfCnpjUtils.applyMask(payer.cpfCnpj.toString())}" disabled="true"><br>
             </div><br>
         </fieldset>
         

--- a/src/main/groovy/com/mini/asaas/utils/CpfCnpjUtils.groovy
+++ b/src/main/groovy/com/mini/asaas/utils/CpfCnpjUtils.groovy
@@ -9,13 +9,19 @@ class CpfCnpjUtils {
     static final int maxLengthCnpj = 14
 
     public static boolean validate(String cpfCnpj) {
-        
-        cpfCnpj = cpfCnpj.replaceAll("[^\\d]", "")
+
+        cpfCnpj = Util.removeNonNumeric(cpfCnpj)
 
         if (cpfCnpj.length() == maxLengthCpf) return isValidCPF(cpfCnpj)
         if (cpfCnpj.length() == maxLengthCnpj) return isValidCNPJ(cpfCnpj)
 
         return false
+    }
+
+    public static String applyMask(String cpfCnpj) {
+        cpfCnpj = Util.removeNonNumeric(cpfCnpj)
+        if (cpfCnpj.length() == maxLengthCpf) return applyCpfMask(cpfCnpj)
+        if (cpfCnpj.length() == maxLengthCnpj) return applyCnpjMask(cpfCnpj)
     }
 
     public static boolean isValidCPF(String cpf) {
@@ -26,24 +32,24 @@ class CpfCnpjUtils {
 
         def sum = 0
         def weight = 10
-        
+
         for (i in 0..<9) {
             sum += (cpf[i].toInteger() * weight)
             weight--
         }
-        
+
         def firstDigit = (11 - (sum % 11)) % 10
-        
+
         sum = 0
         weight = 11
-        
+
         for (i in 0..<10) {
             sum += (cpf[i].toInteger() * weight)
             weight--
         }
-        
+
         def secondDigit = (11 - (sum % 11)) % 10
-        
+
         return cpf[9].toInteger() == firstDigit && cpf[10].toInteger() == secondDigit
     }
 
@@ -52,31 +58,40 @@ class CpfCnpjUtils {
         if (cnpj ==~ /(\d)\1{13}/) {
             return false
         }
-        
+
         def sum = 0
         def weight = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
-        
+
         for (i in 0..<12) {
             sum += (cnpj[i].toInteger() * weight[i])
         }
-        
+
         def firstDigit = sum % 11
         firstDigit = firstDigit < 2 ? 0 : 11 - firstDigit
-        
+
         sum = 0
         weight = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
-        
+
         for (i in 0..<13) {
             sum += (cnpj[i].toInteger() * weight[i])
         }
-        
+
         def secondDigit = (11 - (sum % 11)) % 10
         secondDigit = secondDigit < 2 ? 0 : 11 - secondDigit
-        
+
         return cnpj[12].toInteger() == firstDigit && cnpj[13].toInteger() == secondDigit
     }
 
     public static PersonType getPersonType(String cpfCnpj) {
         return cpfCnpj.size() > maxLengthCpf ? PersonType.LEGAL : PersonType.NATURAL
     }
+
+    private static String applyCpfMask(String cpf) {
+        return cpf.replaceAll("(\\d{3})(\\d{3})(\\d{3})(\\d{2})", "\$1.\$2.\$3-\$4")
+    }
+
+    private static String applyCnpjMask(String cnpj) {
+        return cnpj.replaceAll("(\\d{2})(\\d{3})(\\d{3})(\\d{4})(\\d{2})", "\$1.\$2.\$3/\$4-\$5")
+    }
+
 }

--- a/src/main/groovy/com/mini/asaas/utils/Util.groovy
+++ b/src/main/groovy/com/mini/asaas/utils/Util.groovy
@@ -1,0 +1,7 @@
+package com.mini.asaas.utils
+
+class Util {
+    public static removeNonNumeric(String text) {
+        return text.replaceAll("[^\\d]", "")
+    }
+}


### PR DESCRIPTION
## Impacto
### Agora CpfCnpjUtils possui um método pra mascarar o cpf/cnpj
### Criado um Util com um método para retirar caracteres não numéricos
### O banco não salva cpf com pontuação

## Release Note (Descrição que irá no forno)
###

## PR Predecessora  
### 

## Plano de deploy:
- Antes do deploy:
- Depois do deploy:

## Link da tarefa no JIRA
### https://asaasdev.atlassian.net/browse/PMAKES-45

## Prints do desenvolvimento
![image](https://github.com/KarlaCSF/Mini-Asaas/assets/91269138/58cbaa27-6dd8-4b0a-9bbc-e91e41f80151)
